### PR TITLE
add typo

### DIFF
--- a/poeTransactionCounter.js
+++ b/poeTransactionCounter.js
@@ -82,6 +82,7 @@ const microtransactions = {
     // Expedition
     "Soulkeeper": 30,
     "Soulkeeper Vizier": 60,
+    "Soulkeepr Vizier": 60, //ggg have misspelled this in the account transactions list
     "Soulkeeper Demigod": 90,
     "Aesir": 30,
     "Aesir Warrior": 60,


### PR DESCRIPTION
> shimmed the expedition list for Soulkeeper Vizier's misspelling in the account list. I cannot confirm whether all 'Soulkeeper' packs are this way, I only purchased the Vizier version, so I did not modify the others.
> ~garrettnors

I personally have the `Soulkeeper Demigod` Supporter-Pack. For me it is not misspelled.