### PR TITLE
Add alternate name for Survivor pack

### DIFF
--- a/poeTransactionCounter.js
+++ b/poeTransactionCounter.js
@@ -285,6 +285,7 @@ const microtransactions = {
 
     // Release
     "Survivor Supporter Pack": 50,
+    "Survivor Pack": 50
     "Warrior Supporter Pack": 120,
     "Champion Supporter Pack": 280,
     "Conqueror Supporter Pack": 900,

--- a/poeTransactionCounter.js
+++ b/poeTransactionCounter.js
@@ -285,7 +285,7 @@ const microtransactions = {
 
     // Release
     "Survivor Supporter Pack": 50,
-    "Survivor Pack": 50
+    "Survivor Pack": 50,
     "Warrior Supporter Pack": 120,
     "Champion Supporter Pack": 280,
     "Conqueror Supporter Pack": 900,


### PR DESCRIPTION
The Survivor Supporter pack, on my transactions page, has an alternate name. I've added it

![image](https://github.com/user-attachments/assets/e048c485-0bc9-48e3-8556-b5cb1cc76bf4)
